### PR TITLE
Add Gitea token param

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/gitea_types.go
+++ b/pkg/apis/integreatly/v1alpha1/gitea_types.go
@@ -11,8 +11,9 @@ import (
 type GiteaSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Hostname    string `json:"hostname"`
-	DeployProxy bool   `json:"deployProxy"`
+	Hostname           string `json:"hostname"`
+	DeployProxy        bool   `json:"deployProxy"`
+	GiteaInternalToken string `json:"giteaInternalToken"`
 }
 
 // GiteaStatus defines the observed state of Gitea

--- a/pkg/controller/gitea/templateHelper.go
+++ b/pkg/controller/gitea/templateHelper.go
@@ -3,11 +3,12 @@ package gitea
 import (
 	"bytes"
 	"fmt"
-	integreatlyv1alpha1 "github.com/integr8ly/gitea-operator/pkg/apis/integreatly/v1alpha1"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"text/template"
+
+	integreatlyv1alpha1 "github.com/integr8ly/gitea-operator/pkg/apis/integreatly/v1alpha1"
 )
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
@@ -111,7 +112,7 @@ func newTemplateHelper(cr *integreatlyv1alpha1.Gitea) *GiteaTemplateHelper {
 		DatabaseMaxConnections:  "100",
 		DatabaseSharedBuffers:   "12MB",
 		InstallLock:             true,
-		GiteaInternalToken:      generateToken(105),
+		GiteaInternalToken:      cr.Spec.GiteaInternalToken,
 		GiteaSecretKey:          generateToken(10),
 		GiteaImage:              GiteaImage,
 		GiteaVersion:            GiteaVersion,

--- a/pkg/controller/gitea/templateHelper.go
+++ b/pkg/controller/gitea/templateHelper.go
@@ -112,7 +112,7 @@ func newTemplateHelper(cr *integreatlyv1alpha1.Gitea) *GiteaTemplateHelper {
 		DatabaseMaxConnections:  "100",
 		DatabaseSharedBuffers:   "12MB",
 		InstallLock:             true,
-		GiteaInternalToken:      cr.Spec.GiteaInternalToken,
+		GiteaInternalToken:      giteaInternalTokenSetter(cr),
 		GiteaSecretKey:          generateToken(10),
 		GiteaImage:              GiteaImage,
 		GiteaVersion:            GiteaVersion,
@@ -129,6 +129,14 @@ func newTemplateHelper(cr *integreatlyv1alpha1.Gitea) *GiteaTemplateHelper {
 		Parameters:   param,
 		TemplatePath: templatePath,
 	}
+}
+
+func giteaInternalTokenSetter(cr *integreatlyv1alpha1.Gitea) string {
+	giteaInternalToken := cr.Spec.GiteaInternalToken
+	if giteaInternalToken == "" {
+		giteaInternalToken = generateToken(105)
+	}
+	return giteaInternalToken
 }
 
 // load a template from a given resource name. The template must be located


### PR DESCRIPTION
Accept value from the custom resource for the Gitea token parameter. This value will then be used in the `INTERNAL_TOKEN` property in the config map. 

**Verification**
1. Login to openshift
2. Run `make install`
3. Run `make deploy`
4.  Create a Gitea custom resource with the property `giteaInternalToken` within the `Spec`.
5. Ensure that the `INTERNAL_TOKEN` value in the `gitea-config` config map corresponds to the value in the custom resource.
6. Create a Gitea custom resource without any `giteaInternalToken` property within the `Spec`
7. Ensure that the `INTERNAL_TOKEN` has a default generated value.