### PR TITLE
add gitea config properties to enable reverse proxy authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ spec:
   hostname: <gitea.apps.CLUSTER_URL>
   deployProxy: <Only on OpenShift: deploy OAuth Proxy>
   giteaInternalToken: <Gitea internal token - If no value is specified a token will be generated>
+  reverseProxyAuthenticationUser: <Header name for reverse proxy authentication (Default value: X-WEBAUTH-USER)>
+  enableReverseProxyAuthentication: <Set this to true to allow reverse proxy authentication (Default value: False)>
 ```
 
 An example can be found under `deploy/cr.yaml`

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -3,5 +3,5 @@ kind: Gitea
 metadata:
   name: example-gitea
 spec:
-  hostname: "gitea.apps.pbraun-dcdc.openshiftworkshop.com"
+  hostname: gitea.example.hostname
   deployProxy: True

--- a/pkg/apis/integreatly/v1alpha1/gitea_types.go
+++ b/pkg/apis/integreatly/v1alpha1/gitea_types.go
@@ -11,9 +11,11 @@ import (
 type GiteaSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Hostname           string `json:"hostname"`
-	DeployProxy        bool   `json:"deployProxy"`
-	GiteaInternalToken string `json:"giteaInternalToken"`
+	Hostname                         string `json:"hostname"`
+	DeployProxy                      bool   `json:"deployProxy"`
+	GiteaInternalToken               string `json:"giteaInternalToken"`
+	ReverseProxyAuthenticationUser   string `json:"reverseProxyAuthenticationUser"`
+	EnableReverseProxyAuthentication bool   `json:"enableReverseProxyAuthentication"`
 }
 
 // GiteaStatus defines the observed state of Gitea

--- a/pkg/controller/gitea/templateHelper.go
+++ b/pkg/controller/gitea/templateHelper.go
@@ -61,22 +61,24 @@ type GiteaParameters struct {
 	ProxyServiceAccountName string
 
 	// Resource properties
-	ApplicationNamespace   string
-	ApplicationName        string
-	Hostname               string
-	DatabaseUser           string
-	DatabasePassword       string
-	DatabaseAdminPassword  string
-	DatabaseName           string
-	DatabaseMaxConnections string
-	DatabaseSharedBuffers  string
-	InstallLock            bool
-	GiteaInternalToken     string
-	GiteaSecretKey         string
-	GiteaImage             string
-	GiteaVersion           string
-	GiteaVolumeCapacity    string
-	DbVolumeCapacity       string
+	ApplicationNamespace             string
+	ApplicationName                  string
+	Hostname                         string
+	DatabaseUser                     string
+	DatabasePassword                 string
+	DatabaseAdminPassword            string
+	DatabaseName                     string
+	DatabaseMaxConnections           string
+	DatabaseSharedBuffers            string
+	InstallLock                      bool
+	GiteaInternalToken               string
+	GiteaSecretKey                   string
+	GiteaImage                       string
+	GiteaVersion                     string
+	GiteaVolumeCapacity              string
+	DbVolumeCapacity                 string
+	ReverseProxyAuthenticationUser   string
+	EnableReverseProxyAuthentication bool
 }
 
 type GiteaTemplateHelper struct {
@@ -89,35 +91,37 @@ type GiteaTemplateHelper struct {
 // by the user in the custom resource
 func newTemplateHelper(cr *integreatlyv1alpha1.Gitea) *GiteaTemplateHelper {
 	param := GiteaParameters{
-		GiteaConfigMapName:      GiteaConfigMapName,
-		GiteaDeploymentName:     GiteaDeploymentName,
-		GiteaIngressName:        GiteaIngressName,
-		GiteaPgDeploymentName:   GiteaPgDeploymentName,
-		GiteaPgPvcName:          GiteaPgPvcName,
-		GiteaPgServiceName:      GiteaPgServiceName,
-		GiteaReposPvcName:       GiteaReposPvcName,
-		GiteaServiceAccountName: GiteaServiceAccountName,
-		GiteaServiceName:        GiteaServiceName,
-		ProxyDeploymentName:     ProxyDeploymentName,
-		ProxyRouteName:          ProxyRouteName,
-		ProxyServiceName:        ProxyServiceName,
-		ProxyServiceAccountName: ProxyServiceAccountName,
-		ApplicationNamespace:    cr.Namespace,
-		ApplicationName:         "gitea",
-		Hostname:                cr.Spec.Hostname,
-		DatabaseUser:            "gitea",
-		DatabasePassword:        DatabasePassword,
-		DatabaseAdminPassword:   DatabaseAdminPassword,
-		DatabaseName:            "gitea",
-		DatabaseMaxConnections:  "100",
-		DatabaseSharedBuffers:   "12MB",
-		InstallLock:             true,
-		GiteaInternalToken:      giteaInternalTokenSetter(cr),
-		GiteaSecretKey:          generateToken(10),
-		GiteaImage:              GiteaImage,
-		GiteaVersion:            GiteaVersion,
-		GiteaVolumeCapacity:     "1Gi",
-		DbVolumeCapacity:        "1Gi",
+		GiteaConfigMapName:               GiteaConfigMapName,
+		GiteaDeploymentName:              GiteaDeploymentName,
+		GiteaIngressName:                 GiteaIngressName,
+		GiteaPgDeploymentName:            GiteaPgDeploymentName,
+		GiteaPgPvcName:                   GiteaPgPvcName,
+		GiteaPgServiceName:               GiteaPgServiceName,
+		GiteaReposPvcName:                GiteaReposPvcName,
+		GiteaServiceAccountName:          GiteaServiceAccountName,
+		GiteaServiceName:                 GiteaServiceName,
+		ProxyDeploymentName:              ProxyDeploymentName,
+		ProxyRouteName:                   ProxyRouteName,
+		ProxyServiceName:                 ProxyServiceName,
+		ProxyServiceAccountName:          ProxyServiceAccountName,
+		ApplicationNamespace:             cr.Namespace,
+		ApplicationName:                  "gitea",
+		Hostname:                         cr.Spec.Hostname,
+		DatabaseUser:                     "gitea",
+		DatabasePassword:                 DatabasePassword,
+		DatabaseAdminPassword:            DatabaseAdminPassword,
+		DatabaseName:                     "gitea",
+		DatabaseMaxConnections:           "100",
+		DatabaseSharedBuffers:            "12MB",
+		InstallLock:                      true,
+		GiteaInternalToken:               giteaInternalTokenSetter(cr),
+		GiteaSecretKey:                   generateToken(10),
+		GiteaImage:                       GiteaImage,
+		GiteaVersion:                     GiteaVersion,
+		GiteaVolumeCapacity:              "1Gi",
+		DbVolumeCapacity:                 "1Gi",
+		ReverseProxyAuthenticationUser:   reverseProxyAuthUserSetter(cr),
+		EnableReverseProxyAuthentication: cr.Spec.EnableReverseProxyAuthentication,
 	}
 
 	templatePath := os.Getenv("TEMPLATE_PATH")
@@ -131,15 +135,7 @@ func newTemplateHelper(cr *integreatlyv1alpha1.Gitea) *GiteaTemplateHelper {
 	}
 }
 
-func giteaInternalTokenSetter(cr *integreatlyv1alpha1.Gitea) string {
-	giteaInternalToken := cr.Spec.GiteaInternalToken
-	if giteaInternalToken == "" {
-		giteaInternalToken = generateToken(105)
-	}
-	return giteaInternalToken
-}
-
-// load a templates from a given resource name. The templates must be located
+// load a template from a given resource name. The template must be located
 // under ./templates and the filename must be <resource-name>.yaml
 func (h *GiteaTemplateHelper) loadTemplate(name string) ([]byte, error) {
 	path := fmt.Sprintf("%s/%s.yaml", h.TemplatePath, name)
@@ -160,4 +156,21 @@ func (h *GiteaTemplateHelper) loadTemplate(name string) ([]byte, error) {
 	}
 
 	return buffer.Bytes(), nil
+}
+
+// Resource property setters
+func giteaInternalTokenSetter(cr *integreatlyv1alpha1.Gitea) string {
+	giteaInternalToken := cr.Spec.GiteaInternalToken
+	if giteaInternalToken == "" {
+		giteaInternalToken = generateToken(105)
+	}
+	return giteaInternalToken
+}
+
+func reverseProxyAuthUserSetter(cr *integreatlyv1alpha1.Gitea) string {
+	reverseProxyAuthUser := cr.Spec.ReverseProxyAuthenticationUser
+	if reverseProxyAuthUser == "" {
+		reverseProxyAuthUser = "X-WEBAUTH-USER"
+	}
+	return reverseProxyAuthUser
 }

--- a/templates/gitea-config.yaml
+++ b/templates/gitea-config.yaml
@@ -13,6 +13,7 @@ data:
     INTERNAL_TOKEN = {{ .GiteaInternalToken }}
     INSTALL_LOCK   = true
     SECRET_KEY     = {{ .GiteaSecretKey }}
+    REVERSE_PROXY_AUTHENTICATION_USER = {{ .ReverseProxyAuthenticationUser }}
 
     [database]
     DB_TYPE  = postgres
@@ -50,6 +51,7 @@ data:
     DEFAULT_ALLOW_CREATE_ORGANIZATION = true
     DEFAULT_ENABLE_TIMETRACKING       = true
     NO_REPLY_ADDRESS                  = noreply.example.org
+    ENABLE_REVERSE_PROXY_AUTHENTICATION = {{ .EnableReverseProxyAuthentication }}
 
     [picture]
     DISABLE_GRAVATAR        = false


### PR DESCRIPTION
Allow the following properties to be defined in Gitea's custom resource in order to enable reverse proxy authentication:
- `reverseProxyAuthenticationUser`
- `enableReverseProxyAuthentication`