### PR TITLE
use info log level by default

### DIFF
--- a/templates/gitea-config.yaml
+++ b/templates/gitea-config.yaml
@@ -64,7 +64,7 @@ data:
 
     [log]
     MODE      = file
-    LEVEL     = Trace
+    LEVEL     = Info
     ROOT_PATH = /home/gitea/log
 
     [markup.asciidoc]


### PR DESCRIPTION
Use `Info` instead of `Trace` to avoid polluting the logs.