### PR TITLE
Admin user

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ metadata:
 spec:
   hostname: <gitea.apps.CLUSTER_URL>
   deployProxy: <Only on OpenShift: deploy OAuth Proxy>
-  giteaInternalToken: <Gitea internal token - If no value is specified a token will be generated>
 ```
 
 An example can be found under `deploy/cr.yaml`

--- a/deploy/cr.yaml
+++ b/deploy/cr.yaml
@@ -3,5 +3,5 @@ kind: Gitea
 metadata:
   name: example-gitea
 spec:
-  hostname: "gitea.apps.pbraun-dcdc.openshiftworkshop.com"
-  deployProxy: True
+  hostname: "gitea.apps.127.0.0.1.nip.io"
+  deployProxy: False

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: gitea-operator
       containers:
         - name: gitea-operator
-          image: pb82/gitea-operator:latest
+          image: quay.io/integreatly/gitea-operator:0.0.1
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: gitea-operator
       containers:
         - name: gitea-operator
-          image: quay.io/integreatly/gitea-operator:0.0.1
+          image: pb82/gitea-operator:latest
           ports:
           - containerPort: 60000
             name: metrics

--- a/pkg/apis/integreatly/v1alpha1/gitea_types.go
+++ b/pkg/apis/integreatly/v1alpha1/gitea_types.go
@@ -11,8 +11,8 @@ import (
 type GiteaSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Hostname           string `json:"hostname"`
-	DeployProxy        bool   `json:"deployProxy"`
+	Hostname    string `json:"hostname"`
+	DeployProxy bool   `json:"deployProxy"`
 }
 
 // GiteaStatus defines the observed state of Gitea

--- a/pkg/apis/integreatly/v1alpha1/gitea_types.go
+++ b/pkg/apis/integreatly/v1alpha1/gitea_types.go
@@ -13,7 +13,6 @@ type GiteaSpec struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	Hostname           string `json:"hostname"`
 	DeployProxy        bool   `json:"deployProxy"`
-	GiteaInternalToken string `json:"giteaInternalToken"`
 }
 
 // GiteaStatus defines the observed state of Gitea

--- a/pkg/controller/gitea/templateHelper.go
+++ b/pkg/controller/gitea/templateHelper.go
@@ -112,7 +112,7 @@ func newTemplateHelper(cr *integreatlyv1alpha1.Gitea) *GiteaTemplateHelper {
 		DatabaseMaxConnections:  "100",
 		DatabaseSharedBuffers:   "12MB",
 		InstallLock:             true,
-		GiteaInternalToken:      giteaInternalTokenSetter(cr),
+		GiteaInternalToken:      generateToken(105),
 		GiteaSecretKey:          generateToken(10),
 		GiteaImage:              GiteaImage,
 		GiteaVersion:            GiteaVersion,
@@ -129,14 +129,6 @@ func newTemplateHelper(cr *integreatlyv1alpha1.Gitea) *GiteaTemplateHelper {
 		Parameters:   param,
 		TemplatePath: templatePath,
 	}
-}
-
-func giteaInternalTokenSetter(cr *integreatlyv1alpha1.Gitea) string {
-	giteaInternalToken := cr.Spec.GiteaInternalToken
-	if giteaInternalToken == "" {
-		giteaInternalToken = generateToken(105)
-	}
-	return giteaInternalToken
 }
 
 // load a templates from a given resource name. The templates must be located

--- a/templates/gitea.yaml
+++ b/templates/gitea.yaml
@@ -27,6 +27,9 @@ spec:
         - containerPort: 3000
           protocol: TCP
         resources: {}
+        env:
+          - name: USER
+            value: {{ .ApplicationName }}
         terminationMessagePath: /dev/termination-log
         volumeMounts:
         - name: {{ .GiteaReposPvcName }}

--- a/test/e2e/gitea_test.go
+++ b/test/e2e/gitea_test.go
@@ -135,8 +135,8 @@ func createGiteaCustomResource(t *testing.T, f *framework.Framework, ctx *framew
 			Namespace: namespace,
 		},
 		Spec: giteav1alpha1.GiteaSpec{
-			Hostname:           "example.gitea.host.com",
-			DeployProxy:        deployProxy,
+			Hostname:    "example.gitea.host.com",
+			DeployProxy: deployProxy,
 		},
 	}
 

--- a/test/e2e/gitea_test.go
+++ b/test/e2e/gitea_test.go
@@ -137,7 +137,6 @@ func createGiteaCustomResource(t *testing.T, f *framework.Framework, ctx *framew
 		Spec: giteav1alpha1.GiteaSpec{
 			Hostname:           "example.gitea.host.com",
 			DeployProxy:        deployProxy,
-			GiteaInternalToken: "example-gitea-token",
 		},
 	}
 


### PR DESCRIPTION
Disables the oauth proxy by default and sets a random internal token. Also adds an additional env var to the gitea container: without `USER` set to `gitea` an internal check will fail when creating new users using the cli.