### PR TITLE
Add github files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Description
+<!-- Add a brief and meaningful description. -->
+
+## Expected Behavior
+<!-- Describe the expected behaviour. -->
+
+## Actual Behavior
+<!-- Describe the current/actual behaviour. -->
+
+## Environment
+
+* Operating system: (E.g RHEL 7.6 )
+* OpenShift version:
+<!-- Run the command `oc version` and add the result here. -->
+* Ansible version:
+<!-- Run the command `ansible --version` and add the result here. -->
+* Project Version/Tag: (E.g release-1.0.1)
+
+## Steps to reproduce
+<!-- Describe all steps and pre-requirements which are required to be performed in order to reproduce this scenario. ( E.g 1. Action, 2. Action ... ) -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -12,8 +12,6 @@
 * Operating system: (E.g RHEL 7.6 )
 * OpenShift version:
 <!-- Run the command `oc version` and add the result here. -->
-* Ansible version:
-<!-- Run the command `ansible --version` and add the result here. -->
 * Project Version/Tag: (E.g release-1.0.1)
 
 ## Steps to reproduce

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Motivation
+<!-- Add references to relevant tickets or a short description of what motivated you to do it. -->
+
+## What
+<!-- Add a short answer for: What was done in this PR? (E.g Don't allow users has access to the feature X.) -->
+
+## Why
+<!-- Add a short answer for: Why it was done? (E.g The feature X was deprecated.) -->
+
+## How
+<!-- Add a short answer for: How it was done? (E.g By removing this feature from ... OR By removing just the button but not its implementation ... ) -->
+
+## Verification Steps
+<!--
+Add the steps required to check this change. Following an example.
+
+1. Go to `XX >> YY >> SS`
+2. Create a new item `N` with the info `X`
+3. Try to edit this item
+4. Check if in the left menu the feature X is not so long present.
+-->
+
+## Checklist:
+
+- [ ] Code has been tested locally by PR requester
+- [ ] Changes have been successfully verified by another team member
+
+## Progress
+
+- [x] Finished task
+- [ ] TODO
+
+## Additional Notes
+
+<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->


### PR DESCRIPTION
## Motivation
Add github files in order to follow our standards and the good practice to work with opensource.  

## What
Add github files 

## Why
- Following the [opensource guide](https://opensource.guide/) recommendations and checklists for contributors choose a project to contribute with
- Following our standards
- Help the users/contributor track properly an issue and a PR

## How
Applying the same ones defined in: https://github.com/integr8ly/installation/tree/master/.github

