### PR TITLE
chore: update to 1.6.0

### DIFF
--- a/pkg/controller/gitea/templateHelper.go
+++ b/pkg/controller/gitea/templateHelper.go
@@ -15,7 +15,7 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01
 
 const (
 	GiteaImage              = "docker.io/wkulhanek/gitea"
-	GiteaVersion            = "1.6"
+	GiteaVersion            = "1.6.0"
 	GiteaConfigMapName      = "gitea-config"
 	GiteaDeploymentName     = "gitea"
 	GiteaIngressName        = "gitea-ingress"


### PR DESCRIPTION
According to https://hub.docker.com/r/wkulhanek/gitea/tags/, this is the tag that has the released Gitea 1.6.0