### PR TITLE
remove packr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ setup:
 	@echo setup complete run make build deploy to build and deploy the operator to a local cluster
 
 .PHONY: build-image
-build-image: packr compile build packr-clean
+build-image: build
 
 .PHONY: build
 build:


### PR DESCRIPTION
We don't use packr in the gitea-operator, removing the makefile steps.