### PR TITLE
Add go environment variables required by the operator sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ generate:
 
 .PHONY: compile
 compile:
-	go build -o=$(COMPILE_OUTPUT) ./cmd/manager/main.go
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o=$(COMPILE_OUTPUT) ./cmd/manager/main.go
 
 .PHONY: check
 check: check-gofmt test-unit


### PR DESCRIPTION
 * Add go environment variables required by the operator sdk https://github.com/operator-framework/operator-sdk/blob/master/commands/operator-sdk/cmd/build.go#L141
