### PR TITLE
Create Jenkinsfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ env:
 stages:
   - test
   - compile
-  - name: push
-    if: fork = false
 
 jobs:
   include:
@@ -23,11 +21,3 @@ jobs:
     - stage: compile
       script:
         - make setup/dep setup/travis image/build TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
-    - stage: push
-      script:
-        - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-        - export TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
-        - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io
-        - make setup/dep setup/travis image/build/push TAG=$TAG
-        - docker tag quay.io/integreatly/$OPERATOR_NAME:$TAG quay.io/integreatly/$OPERATOR_NAME:$BRANCH
-        - docker push quay.io/integreatly/$OPERATOR_NAME:$BRANCH

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,109 @@
+#!groovy
+
+// https://github.com/feedhenry/fh-pipeline-library
+@Library('fh-pipeline-library') _
+
+stage('Trust') {
+    enforceTrustedApproval('aerogear')
+}
+
+def operatorName = "gitea-operator"
+def openshiftProjectName = "test-${operatorName}-${currentBuild.number}-${currentBuild.startTimeInMillis}"
+def operatorDockerImageName = "docker-registry.default.svc:5000/${openshiftProjectName}/${operatorName}-test:latest"
+def testFileName = 'go-test.sh'
+
+def testFileContent = """#!/bin/sh
+${operatorName}-test -test.parallel=1 -test.failfast -root=/ -kubeconfig=incluster -namespacedMan=namespaced.yaml -test.v
+"""
+
+def dockerfileContent = """
+FROM alpine:3.6
+USER nobody
+ADD templates/*.yaml /usr/local/bin/templates/
+ADD ${operatorName} /usr/local/bin/${operatorName}
+ADD ${operatorName}-test /usr/local/bin/${operatorName}-test
+ADD deploy/operator.yaml /namespaced.yaml
+ADD go-test.sh /go-test.sh
+"""
+
+node ('operator-sdk') {
+    stage ('Checkout') {
+        checkout scm
+    }
+    stage('Vendor the dependencies') {
+        sh 'dep ensure'
+    }
+
+    openshift.withCluster('operators-test-cluster') {
+        generateKubeConfig()
+
+        stage('New project in OpenShift') {
+            openshift.newProject(openshiftProjectName)
+        }
+
+        openshift.withProject(openshiftProjectName) {
+            stage("Build ${operatorName} & ${operatorName}-test binaries") {
+                sh """
+                export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
+                go build -o ${operatorName} cmd/manager/main.go
+                go test -c -o ${operatorName}-test ./test/e2e/...
+                """
+            }
+
+            stage("Create test file ${testFileName}") {
+                writeFile file: testFileName, text: testFileContent
+                sh "chmod +x ${testFileName}"
+            }
+
+            stage("Create a Dockerfile for ${operatorName}-test") {
+                writeFile file: "Dockerfile", text: "${dockerfileContent}"
+            }
+
+            stage("Modify operator image name in operator deployment file") {
+                sh "yq w -i deploy/operator.yaml spec.template.spec.containers[0].image ${operatorDockerImageName}"
+            }
+
+            stage("Create necessary resources") {
+                sh """
+                kubectl apply -f deploy/crds/crd.yaml -n ${openshiftProjectName} || true
+                kubectl create -f deploy/service_account.yaml -n ${openshiftProjectName}
+                kubectl create -f deploy/role.yaml -n ${openshiftProjectName}
+                kubectl create -f deploy/role_binding.yaml -n ${openshiftProjectName}
+                """
+            }
+
+            stage("Start OpenShift Build of operator image") {
+                def nb = openshift.newBuild("--name=${operatorName}-test", "--binary")
+                openshift.startBuild("${operatorName}-test", "--from-dir=.")
+                def buildSelector = nb.narrow("bc").related("builds")
+
+                try {
+                    timeout(1) {
+                        buildSelector.untilEach(1) {
+                            def buildPhase = it.object().status.phase
+                            println("Build phase:" + buildPhase)
+                            return (it.object().status.phase == "Complete")
+                        }
+                    }
+                } catch (Exception e) {
+                    buildSelector.logs()
+                    openshift.delete("project", openshiftProjectName)
+                    error "Build timed out"
+                }
+            }
+
+            stage('Test operator') {
+                try {
+                    sh "operator-sdk test cluster ${operatorDockerImageName} --namespace ${openshiftProjectName} --service-account ${operatorName}"
+                } catch (Exception e) {
+                    openshift.delete("project", openshiftProjectName)
+                    error "Test of ${operatorName} has failed."
+                }
+            }
+        }
+
+        stage('Delete OpenShift project') {
+            openshift.delete("project", openshiftProjectName)
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,109 +1,268 @@
-#!groovy
-
-// https://github.com/feedhenry/fh-pipeline-library
-@Library('fh-pipeline-library') _
-
-stage('Trust') {
-    enforceTrustedApproval('aerogear')
-}
-
-def operatorName = "gitea-operator"
-def openshiftProjectName = "test-${operatorName}-${currentBuild.number}-${currentBuild.startTimeInMillis}"
-def operatorDockerImageName = "docker-registry.default.svc:5000/${openshiftProjectName}/${operatorName}-test:latest"
-def testFileName = 'go-test.sh'
-
-def testFileContent = """#!/bin/sh
-${operatorName}-test -test.parallel=1 -test.failfast -root=/ -kubeconfig=incluster -namespacedMan=namespaced.yaml -test.v
-"""
-
-def dockerfileContent = """
-FROM alpine:3.6
-USER nobody
-ADD templates/*.yaml /usr/local/bin/templates/
-ADD ${operatorName} /usr/local/bin/${operatorName}
-ADD ${operatorName}-test /usr/local/bin/${operatorName}-test
-ADD deploy/operator.yaml /namespaced.yaml
-ADD go-test.sh /go-test.sh
-"""
-
-node ('operator-sdk') {
-    stage ('Checkout') {
-        checkout scm
-    }
-    stage('Vendor the dependencies') {
-        sh 'dep ensure'
+pipeline {
+    agent {
+        node {
+            label 'operator-sdk'
+        }
     }
 
-    openshift.withCluster('operators-test-cluster') {
-        generateKubeConfig()
+    libraries {
+        lib('fh-pipeline-library')
+    }
+    
+    environment {
+        GOPATH = "${env.WORKSPACE}/"
+        PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+        GOOS = "linux"
+        GOARCH = "amd64"
+        CGO_ENABLED = 0
+        OPERATOR_NAME = "gitea-operator"
+        OPERATOR_TEST_NAME = "${env.OPERATOR_NAME}-test"
+        OPENSHIFT_PROJECT_NAME = "test-${env.OPERATOR_NAME}-${currentBuild.number}-${currentBuild.startTimeInMillis}"
+        CLONED_REPOSITORY_PATH = "src/github.com/integr8ly/gitea-operator"
+        OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME = "quay.io/integreatly/${env.OPERATOR_NAME}:candidate-${env.BRANCH_NAME}"
+        OPERATOR_CONTAINER_IMAGE_NAME = "quay.io/integreatly/${env.OPERATOR_NAME}:${env.BRANCH_NAME}"
+        OPERATOR_CONTAINER_IMAGE_NAME_LATEST = "quay.io/integreatly/${env.OPERATOR_NAME}:latest"
+        OPERATOR_TEST_CONTAINER_IMAGE_NAME = "docker-registry.default.svc:5000/${env.OPENSHIFT_PROJECT_NAME}/${env.OPERATOR_TEST_NAME}:latest"
+    }
+    
+    options {
+        checkoutToSubdirectory("src/github.com/integr8ly/gitea-operator")
+    }
 
-        stage('New project in OpenShift') {
-            openshift.newProject(openshiftProjectName)
+    stages {
+        stage("Trust"){
+            steps{
+                enforceTrustedApproval('integr8ly')
+            }
+            post{
+                failure{
+                    echo "====++++'Trust' execution failed++++===="
+                    echo "You are not authorized to run this job"
+                }
+        
+            }
         }
 
-        openshift.withProject(openshiftProjectName) {
-            stage("Build ${operatorName} & ${operatorName}-test binaries") {
-                sh """
-                export GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-                go build -o ${operatorName} cmd/manager/main.go
-                go test -c -o ${operatorName}-test ./test/e2e/...
-                """
+        stage("Create an OpenShift project") {
+            steps {
+                script {
+                    openshift.withCluster('operators-test-cluster') {
+                        generateKubeConfig()
+                        openshift.newProject(env.OPENSHIFT_PROJECT_NAME)
+                    }
+                }
             }
+        }
 
-            stage("Create test file ${testFileName}") {
-                writeFile file: testFileName, text: testFileContent
-                sh "chmod +x ${testFileName}"
+        stage("Build code binary"){
+            steps{
+                dir("${env.CLONED_REPOSITORY_PATH}") {
+                    script {
+                        sh """
+                        make code/compile
+                        """
+                    }
+                }
             }
-
-            stage("Create a Dockerfile for ${operatorName}-test") {
-                writeFile file: "Dockerfile", text: "${dockerfileContent}"
+            post{
+                failure{
+                    echo "====++++'Build code binary' execution failed++++===="
+                    echo "Try to run 'make code/compile' locally and make sure it pass"
+                }
             }
+        }
+        stage("Build & push container image") {
+            steps{
+                dir("${env.CLONED_REPOSITORY_PATH}") {
+                    script {
+                        withCredentials([usernamePassword(credentialsId: 'quay-integreatly-bot', usernameVariable: 'quayUsername', passwordVariable: "quayPassword")]) {
+                            final String buildConfig = """
+                            {
+                                "apiVersion": "build.openshift.io/v1",
+                                "kind": "BuildConfig",
+                                "metadata": {
+                                    "labels": {
+                                    "build": "${env.OPERATOR_NAME}"
+                                    },
+                                    "name": "${env.OPERATOR_NAME}"
+                                },
+                                "spec": {
+                                    "runPolicy": "Serial",
+                                    "failedBuildsHistoryLimit": 1,
+                                    "successfulBuildsHistoryLimit": 1,
+                                    "source": {
+                                        "binary": {},
+                                        "type": "Binary"
+                                    },
+                                    "strategy": {
+                                        "dockerStrategy": {
+                                            "dockerfilePath": "build/Dockerfile"
+                                        },
+                                        "type": "Docker"
+                                        },
+                                    "output": {
+                                        "to": {
+                                            "kind": "DockerImage",
+                                            "name": "${env.OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}"
+                                        },
+                                        "pushSecret": {
+                                            "name": "quay-bot"
+                                        }
+                                    }
+                                }
+                            }
+                            """
+                            openshift.withCluster('operators-test-cluster') {
+                                openshift.withProject(env.OPENSHIFT_PROJECT_NAME) {
+                                    openshift.create(
+                                        "secret", "docker-registry", "quay-bot",
+                                        "--docker-username=${quayUsername}",
+                                        "--docker-password=${quayPassword}", "--docker-server=quay.io"
+                                        )
+                                    openshift.apply buildConfig
+                                    def build = openshift.startBuild("${env.OPERATOR_NAME}", "--from-dir=.")
 
-            stage("Modify operator image name in operator deployment file") {
-                sh "yq w -i deploy/operator.yaml spec.template.spec.containers[0].image ${operatorDockerImageName}"
-            }
-
-            stage("Create necessary resources") {
-                sh """
-                kubectl apply -f deploy/crds/crd.yaml -n ${openshiftProjectName} || true
-                kubectl create -f deploy/service_account.yaml -n ${openshiftProjectName}
-                kubectl create -f deploy/role.yaml -n ${openshiftProjectName}
-                kubectl create -f deploy/role_binding.yaml -n ${openshiftProjectName}
-                """
-            }
-
-            stage("Start OpenShift Build of operator image") {
-                def nb = openshift.newBuild("--name=${operatorName}-test", "--binary")
-                openshift.startBuild("${operatorName}-test", "--from-dir=.")
-                def buildSelector = nb.narrow("bc").related("builds")
-
-                try {
-                    timeout(1) {
-                        buildSelector.untilEach(1) {
-                            def buildPhase = it.object().status.phase
-                            println("Build phase:" + buildPhase)
-                            return (it.object().status.phase == "Complete")
+                                    waitUntil {
+                                        build.object().status.phase == "Running"
+                                    }
+                                    build.logs('-f')
+                                }
+                            }
                         }
                     }
-                } catch (Exception e) {
-                    buildSelector.logs()
-                    openshift.delete("project", openshiftProjectName)
-                    error "Build timed out"
                 }
             }
-
-            stage('Test operator') {
-                try {
-                    sh "operator-sdk test cluster ${operatorDockerImageName} --namespace ${openshiftProjectName} --service-account ${operatorName}"
-                } catch (Exception e) {
-                    openshift.delete("project", openshiftProjectName)
-                    error "Test of ${operatorName} has failed."
+            post{
+                failure{
+                    echo "====++++'Build & push container image' execution failed++++===="
                 }
             }
         }
-
-        stage('Delete OpenShift project') {
-            openshift.delete("project", openshiftProjectName)
+        stage("Build test binary"){
+            steps{
+                dir("${env.CLONED_REPOSITORY_PATH}") {
+                    script {
+                        sh """
+                        make test/compile
+                        """
+                    }
+                }
+            }
+            post{
+                failure{
+                    echo "====++++'Build test binary' execution failed++++===="
+                    echo "Try to run 'make test/compile' locally and make sure it pass"
+                }
+            }
+        }
+        stage("Build operator-test image") {
+            steps{
+                dir("${env.CLONED_REPOSITORY_PATH}") {
+                    script {
+                        def operatorTestDockerfileContent = """
+                        FROM ${env.OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME}
+                        ADD build/_output/bin/gitea-operator-test /usr/local/bin/gitea-operator-test
+                        ADD deploy/operator.yaml /namespaced.yaml
+                        ADD build/test-framework/go-test.sh /go-test.sh
+                        """
+                        openshift.withCluster('operators-test-cluster') {
+                            openshift.withProject(env.OPENSHIFT_PROJECT_NAME) {
+                                writeFile file: "Dockerfile", text: "${operatorTestDockerfileContent}"
+                                sh "yq w -i deploy/operator.yaml spec.template.spec.containers[0].image ${env.OPERATOR_TEST_CONTAINER_IMAGE_NAME}"
+                                openshift.newBuild("--name=${env.OPERATOR_TEST_NAME}", "--binary")
+                                def build = openshift.startBuild("${env.OPERATOR_TEST_NAME}", "--from-dir=.")
+                                waitUntil {
+                                    build.object().status.phase == "Running"
+                                }
+                                build.logs('-f')
+                            }
+                        }
+                    }
+                }
+            }
+            post{
+                failure{
+                    echo "====++++Build operator-test image execution failed++++===="
+                }
+        
+            }
+        }
+        stage("Test operator") {
+            steps{
+                dir("${env.CLONED_REPOSITORY_PATH}") {
+                    script {
+                        openshift.withCluster('operators-test-cluster') {
+                            openshift.withProject(env.OPENSHIFT_PROJECT_NAME) {
+                                sh """
+                                make NAMESPACE=${env.OPENSHIFT_PROJECT_NAME} cluster/prepare
+                                operator-sdk test cluster ${env.OPERATOR_TEST_CONTAINER_IMAGE_NAME} --namespace ${env.OPENSHIFT_PROJECT_NAME} --service-account ${env.OPERATOR_NAME}
+                                """
+                            }
+                        }
+                    }
+                }
+            }
+            post{
+                failure{
+                    echo "====++++Test operator execution failed++++===="
+                }
+            }
+        }
+        stage("Retag the image if the test passed and delete an old tag") {
+            steps{
+                withCredentials([usernameColonPassword(credentialsId: 'quay-integreatly-bot', variable: 'QUAY_CREDS')]) {
+                    retry(3) {
+                        sh """
+                            skopeo copy \
+                              --src-creds ${env.QUAY_CREDS} \
+                              --dest-creds ${env.QUAY_CREDS} \
+                              docker://${env.OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME} \
+                              docker://${env.OPERATOR_CONTAINER_IMAGE_NAME}
+                        """
+                    }
+                    retry(3) {
+                        sh """
+                            skopeo delete \
+                              --creds ${env.QUAY_CREDS} \
+                              docker://${env.OPERATOR_CONTAINER_IMAGE_CANDIDATE_NAME} \
+                        """
+                    }
+                }
+            }
+        }
+        stage("Create a 'latest' tag from 'master'") {
+            when {
+                branch 'master'
+            }
+            steps{
+                withCredentials([usernameColonPassword(credentialsId: 'quay-integreatly-bot', variable: 'QUAY_CREDS')]) {
+                    retry(3) {
+                        sh """
+                            skopeo copy \
+                              --src-creds ${env.QUAY_CREDS} \
+                              --dest-creds ${env.QUAY_CREDS} \
+                              docker://${env.OPERATOR_CONTAINER_IMAGE_NAME} \
+                              docker://${env.OPERATOR_CONTAINER_IMAGE_NAME_LATEST}
+                        """
+                    }
+                }
+            }
+        }
+    }
+    post {
+        always{
+            script {
+                openshift.withCluster('operators-test-cluster') {
+                    openshift.delete("project", env.OPENSHIFT_PROJECT_NAME)
+                }
+            }
+        }
+        failure {
+            mail(
+                to: 'psturc@redhat.com',
+                subject: 'Gitea Operator build failed',
+                body: "See the pipeline here: ${env.RUN_DISPLAY_URL}"
+            )
         }
     }
 }

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL= /bin/bash
 TAG ?= 0.0.3
 PKG = github.com/integr8ly/gitea-operator
 COMPILE_OUTPUT = build/_output/bin/gitea-operator
+TEST_COMPILE_OUTPUT = build/_output/bin/gitea-operator-test
 
 .PHONY: setup/dep
 setup/dep:
@@ -60,6 +61,10 @@ test/unit:
 test/e2e:
 	@echo Running e2e tests:
 	operator-sdk test local ./test/e2e --go-test-flags "-v"
+
+.PHONY: test/compile
+test/compile:
+	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o=$(TEST_COMPILE_OUTPUT) ./test/e2e/...
 
 .PHONY: cluster/prepare
 cluster/prepare:

--- a/build/test-framework/go-test.sh
+++ b/build/test-framework/go-test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+gitea-operator-test -test.parallel=1 -test.failfast -root=/ -kubeconfig=incluster -namespacedMan=namespaced.yaml -test.v


### PR DESCRIPTION
## What

This PR introduces PR-based E2E testing of operators.

## How

This repository is watched by our internal Jenkins instance.

When the job starts, a new slave is being spawn on internal OpenShift cluster as a pod and it has access to that OpenShift instance (so it can do CRUDL ops. on projects).

It creates an image for the Operator-test and builds it (with openshift builder) and runs the test as a pod in the project.

One stage of the pipeline is also building & pushing the gitea-operator image to quay.io registry, which was removed from travis job

## Verification steps

1. Target some cluster with oc (with cluster-admin privileges)
2. Run
   ```
   export IMAGE="quay.io/integreatly/gitea-operator:pr-operator-test"
   operator-sdk test local ./test/e2e --image $IMAGE --go-test-flags "-v"
   ```

Feedback, suggestions appreciated