### PR TITLE
Provides an operator nested bundle for registry usage

### DIFF
--- a/deploy/olm-catalog/gitea-operator/0.0.5/crd.yaml
+++ b/deploy/olm-catalog/gitea-operator/0.0.5/crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: giteas.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: Gitea
+    listKind: GiteaList
+    plural: giteas
+    singular: gitea
+  scope: Namespaced
+  version: v1alpha1

--- a/deploy/olm-catalog/gitea-operator/0.0.5/gitea-operator.v0.0.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/gitea-operator/0.0.5/gitea-operator.v0.0.5.clusterserviceversion.yaml
@@ -1,0 +1,121 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+  name: gitea-operator.v0.0.5
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Gitea
+      name: giteas.integreatly.org
+      version: v1alpha1
+      displayName: Gitea
+      description: Provides one managed Gitea instance per CR, deleted upon deletion of the CR.
+  description: An Operator that installs Gitea. Installation is performed by creating a custom resource of kind Gitea. You can uninstall Gitea by removing this resource. The Operator will also watch all Gitea resources and reinstall them if they are deleted.
+  displayName: Gitea Operator
+  install:
+    spec:
+      deployments:
+      - name: gitea-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: gitea-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: gitea-operator
+            spec:
+              containers:
+              - command:
+                - gitea-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: gitea-operator
+                - name: TEMPLATE_PATH
+                  value: /usr/local/bin/templates
+                image: quay.io/integreatly/gitea-operator:master
+                imagePullPolicy: Always
+                name: gitea-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: gitea-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        serviceAccountName: gitea-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  maturity: alpha
+  provider: {}
+  version: 0.0.5

--- a/deploy/olm-catalog/gitea-operator/gitea-operator.package.yaml
+++ b/deploy/olm-catalog/gitea-operator/gitea-operator.package.yaml
@@ -1,0 +1,5 @@
+channels:
+- currentCSV: gitea-operator.v0.0.5
+  name: alpha
+defaultChannel: alpha
+packageName: gitea-operator


### PR DESCRIPTION
This provides an operator bundle in the current preferred nested format so this operator can be included in registries like operatorhub.io.

## Motivation & Why
I needed this for my own usage so we can deliver via an operator catalog as part of a bigger project. 

## What & How
Used operator-sdk to create a basic bundle under deploy/olm-catalog.

## Verification Steps

Better method:
1. Add the deploy/olm-catalog/gitea-operator/ directory to your operator registry process to be included in your operator catalog
2. Run your catalog build process
3. Subscribe to the operator from the catalog

CSV check method:
1. Create your service account, crd, role and role_binding manually.
2 Modify namespace in deploy/olm-catalog/gitea-operator/0.0.5/gitea-operator.v0.0.5.clusterserviceversion.yaml
3. kubectl/oc create -f deploy/olm-catalog/gitea-operator/0.0.5/gitea-operator.v0.0.5.clusterserviceversion.yaml

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member

## Progress

- [x] Finished task

